### PR TITLE
Null column prevention

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -494,7 +494,7 @@
             return true;
           }
         });
-        if(this._cellChanged(this._readContent(this._internalData[index], column), changeRec.value)){
+        if(column != null && this._cellChanged(this._readContent(this._internalData[index], column), changeRec.value)){
           this._handleValidateEvent(evt);
         }
       }


### PR DESCRIPTION
## Description: 

column.name in _readContent will throw an exception when column is null. We can prevent this by checking column before calling _readContent.

Also evt isn't defined in this scope, should line 498 be removed, or should evt be created with the proper values?

## Related issue: 

https://github.com/PredixDev/px-data-table/issues/110

