### PR TITLE
Provide intended behavior for the select-all checkbox

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -667,7 +667,8 @@
       //update selected rows when changing the filter if the select all is enabled
       var selectAllCheckbox = Polymer.dom(this.root).querySelector("#selectAllCheckbox");
       if(selectAllCheckbox !== null && selectAllCheckbox !== undefined && selectAllCheckbox.checked){
-          selectAllCheckbox.checked=false;
+          this._setAllRows(false);
+          this._setAllRows(true);
       }
     },
 


### PR DESCRIPTION
Proposal for revision of the select-all checkbox.

## Make the select-all checkbox work as intended with filtering:
This simple pull-request revises how the select-all checkbox works when combined with filtering. Previously, when someone checked the select-all checkbox and filtered, the filter would deselect the select-all checkbox, but the rows would remain selected, meaning that in the view there could be 2 selected rows with 3 other hidden rows.
# Steps to observe results:
## Previously
1. Check the 'select-all checkbox' with multiple rows visible.
2. Filter the results in any way
3. Observe that the selected row count remains the same, but that the 'select-all checkbox' becomes unchecked, and that some selected rows are filtered out/hidden.
## With this PR
1. Check the 'select-all checkbox' with multiple rows visible.
2. Filter the results in any way
3. Observe that the selected row count is updated to show the filtered row count, and that no hidden rows remain selected

## Reviewed by...
@aaflet01 and @mjgerace

Previous discussion about this issue [can be seen at the predix forum](http://forum.predix.io/questions/15452/px-data-table-filters-and-selection.html).
