### PR TITLE
Bug161

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -570,21 +570,23 @@
 
 
     _generateMetaFromData: function() {
+      var newMeta = [];
       for(var prop in this.data[0]) {
-        var previousNode,
-            notFound = this.meta.every(function(column, index) {
-              if(column.name === prop) {
-                return false;
-              }
-              return true;
-            });
+        // var previousNode,
+        //     notFound = this.meta.every(function(column, index) {
+        //       if(column.name === prop) {
+        //         return false;
+        //       }
+        //       return true;
+        //     });
 
-        // if column not found
-        if(notFound) {
+        // // if column not found
+        // if(notFound) {
           var colInfo = this._generateMetaForColumn(prop, "string", false, prop.charAt(0).toUpperCase() + prop.slice(1));
-          this.push('meta', colInfo);
-        }
+          newMeta.push(colInfo);
+        // }
       }
+      this.set('meta', newMeta);
     },
 
 

--- a/aha-table.html
+++ b/aha-table.html
@@ -571,6 +571,9 @@
 
     _generateMetaFromData: function() {
       var newMeta = [];
+      if(this._selectedColumnExists() && this.meta[0].name === '_selected') {
+        newMeta.push(this.meta[0]);
+      }
       for(var prop in this.data[0]) {
         var colInfo = this._generateMetaForColumn(prop, "string", false, prop.charAt(0).toUpperCase() + prop.slice(1));
         newMeta.push(colInfo);

--- a/aha-table.html
+++ b/aha-table.html
@@ -572,19 +572,8 @@
     _generateMetaFromData: function() {
       var newMeta = [];
       for(var prop in this.data[0]) {
-        // var previousNode,
-        //     notFound = this.meta.every(function(column, index) {
-        //       if(column.name === prop) {
-        //         return false;
-        //       }
-        //       return true;
-        //     });
-
-        // // if column not found
-        // if(notFound) {
-          var colInfo = this._generateMetaForColumn(prop, "string", false, prop.charAt(0).toUpperCase() + prop.slice(1));
-          newMeta.push(colInfo);
-        // }
+        var colInfo = this._generateMetaForColumn(prop, "string", false, prop.charAt(0).toUpperCase() + prop.slice(1));
+        newMeta.push(colInfo);
       }
       this.set('meta', newMeta);
     },


### PR DESCRIPTION
Martin, this seems to resolve #161 by re-creating the meta based on the data provided instead of looping through it and only adding new columns. It was the only way I could think of to detect removed columns. I've tested the functionality locally (turning on and off selectable / includeAllColumns, mutating the tableData, etc) and it all seems to work fine. Can you think of any possible ramifications? The failing unit test in WCT is on completely different functionality, but I have a sneaky feeling it could be related to the (presumed) performance hit of re-building the meta in this way. Any ideas?