### PR TITLE
Added attribute to data-table-column that will stop row selection, 

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -675,6 +675,7 @@
         type: type,
         sortable: this.sortable,
         filterable: this.filterable,
+        selectable: this.selectable ? "" : "false",
         editable: false,
         required: false,
         hide: false,
@@ -1174,7 +1175,7 @@
           row = evt.model.internalRow,
           detail = {"row": row, "column": column},
           selectAllCheckbox;
-      if(column.editable || column.type === 'dropdown') return;
+      if(column.editable || column.type === 'dropdown' || column.selectable === 'false') return;
 
       if (this.selectable) {
         this._selectRow(row, this.$.recordList.indexForElement(evt.currentTarget));

--- a/aha-table.html
+++ b/aha-table.html
@@ -675,7 +675,7 @@
         type: type,
         sortable: this.sortable,
         filterable: this.filterable,
-        selectable: this.selectable ? "" : "false",
+        disableSelect: !this.selectable,
         editable: false,
         required: false,
         hide: false,
@@ -1175,7 +1175,7 @@
           row = evt.model.internalRow,
           detail = {"row": row, "column": column},
           selectAllCheckbox;
-      if(column.editable || column.type === 'dropdown' || column.selectable === 'false') return;
+      if(column.editable || column.type === 'dropdown' || column.disableSelect === true) return;
 
       if (this.selectable) {
         this._selectRow(row, this.$.recordList.indexForElement(evt.currentTarget));

--- a/px-data-table-column.html
+++ b/px-data-table-column.html
@@ -101,13 +101,11 @@ Click [here](https://www.predix-ui.com/#/components/px-validation/) for more inf
       },
 
       /**
-       * If unset, will default to selectable
-       * If set to 'false', clicking a cell under this column will not trigger selecting that row
-       * This is a string instead of a boolean so that it defaults to true and changes to false, instead of the reverse (which is standard behavior for boolean attributes)
+       * If true, clicking a cell in this column will not select the row
       */
-      selectable: {
-        type: String,
-        value: ""
+      disableSelect: {
+        type: Boolean,
+        value: false
       },
       
       /**

--- a/px-data-table-column.html
+++ b/px-data-table-column.html
@@ -101,6 +101,16 @@ Click [here](https://www.predix-ui.com/#/components/px-validation/) for more inf
       },
 
       /**
+       * If unset, will default to selectable
+       * If set to 'false', clicking a cell under this column will not trigger selecting that row
+       * This is a string instead of a boolean so that it defaults to true and changes to false, instead of the reverse (which is standard behavior for boolean attributes)
+      */
+      selectable: {
+        type: String,
+        value: ""
+      },
+      
+      /**
        * Full path to the custom function (attached to `window`) to sort this row with.
        * We highly suggest namespacing this function name so you don't pollute the global namespace and so you can have multiple datatables with different sorting functions.
        *


### PR DESCRIPTION
Defaults to current behavior.

With this, one can add the attribute `selectable='false'` to a px-data-table-column, and then clicking any cell in that column will not trigger selecting that cell's row.

Use-case: Having action buttons in a column `Actions`.  Clicking these trigger the desired action but also select the row (undesired).  With this, the `Actions` column alone can be 'un-selectable' and the remaining columns will behave as normal.

Note: I used a string instead of a boolean so that this wouldn't break existing implementations.  Boolean attributes default to false (when not present).