### PR TITLE
Updating the version based on recent fixes.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+v6.1.3
+==================
+* Fixed a bug when column that is initially hidden ("hide" attribute present in DOM when created) has no filter box when picked via the column chooser.
+* Fixed a bug causing an edit made on any page other than page 1 to navigate back to page 1.
+
 v6.1.2
 ==================
 * Remove ES6 arrow function

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-data-table",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "main": [
     "px-data-table.html"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-data-table",
   "author": "General Electric",
   "description": "A Px component",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "extName": null,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changed Version to 6.1.3
* Fixed a bug when column that is initially hidden ("hide" attribute present in DOM when created) has no filter box when picked via the column chooser.
* Fixed a bug causing an edit made on any page other than page 1 to navigate back to page 1.
