### PR TITLE
Fix first column not highlighted if table is not selectable

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -555,7 +555,7 @@ limitations under the License.
       column._highLightElLoadedCount += 1;
       if (column._highLightElLoadedCount === Polymer.dom(column).querySelectorAll('px-data-table-highlight').length) {
         var columnIndex = this._findMetaIndexFromColumnElement(column);
-        if (columnIndex > 0) {
+        if (columnIndex > 0  || !this.selectable) {
           this.set('meta.' + columnIndex + '.highlightdefined', true);
         }
       }


### PR DESCRIPTION
# Pull Request

Fix for Issue #214

## Description
The highlighting of the column of index 0 is not possible.
This should only be the case when the table is selectable (in that case, we don't want to highlight the selection checkbox column)

I have modified the highlighting condition in order to take into account the selectable boolean and allow the column 0 if the table is not selectable.


